### PR TITLE
changes to workflow to support zip product, products in general

### DIFF
--- a/ifcb2/__init__.py
+++ b/ifcb2/__init__.py
@@ -18,6 +18,8 @@ HDR_PATH='hdr_path'
 ADC_PATH='adc_path'
 ROI_PATH='roi_path'
 
+FILE_PATH='file_path'
+
 IFCB_RESOLVER_BASE_PATH='oii/ifcb2/resolvers'
 
 class ResolverError(Exception):

--- a/ifcb2/accession.py
+++ b/ifcb2/accession.py
@@ -92,11 +92,11 @@ class Accession(object):
                 yield fs
     def add_fileset(self,fileset):
         """run one bin fileset through accession process. does not commit,
-        returns True if fileset was good and not skipped, False otherwise"""
+        returns True if fileset was good or already existed, False otherwise"""
         lid = fileset[LID] # get LID from fileset
         if self.bin_exists(lid): # make sure it doesn't exist
             logging.warn('SKIP %s - exists' % lid)
-            return False
+            return True
         b = self.new_bin(lid) # create new bin
         # now compute fixity
         logging.warn('FIXITY computing fixity for %s' % lid)

--- a/ifcb2/files.py
+++ b/ifcb2/files.py
@@ -1,5 +1,5 @@
-from oii.ifcb2 import get_resolver
-from oii.ifcb2.identifiers import parse_pid
+from oii.ifcb2 import get_resolver, FILE_PATH, TS_LABEL
+from oii.ifcb2.identifiers import parse_pid, PRODUCT
 from oii.ifcb2.orm import DataDirectory, TimeSeries
 
 from oii.ldr import pprint
@@ -32,4 +32,11 @@ def get_data_roots(session, ts_label, product_type='raw'):
                 .filter(DataDirectory.product_type==product_type)
     return [dd.path for dd in dds]
 
-
+def get_product_destination(session, pid, product_type=None):
+    parsed = parse_pid(pid)
+    if product_type is not None:
+        parsed[PRODUCT] = product_type
+    ts_label = parsed[TS_LABEL]
+    root = get_data_roots(session, ts_label)[0]
+    S = next(get_resolver().ifcb.files.product_path(root=root,**parsed))
+    return S[FILE_PATH]

--- a/ifcb2/represent.py
+++ b/ifcb2/represent.py
@@ -107,6 +107,13 @@ def bin2json(pid,hdr,targets,timestamp):
     return json.dumps(bin2dict(pid,hdr,targets,timestamp))
 
 def bin2zip(parsed_pid,canonical_pid,targets,hdr,timestamp,roi_path,outfile):
+    """parsed_pid - result of parsing pid
+    canonical_pid - canonicalized with URL prefix
+    targets - list of (stitched) targets
+    hdr - result of parsing header file
+    timestamp - timestamp (FIXME in what format?)
+    roi_path - path to ROI file
+    outfile - where to write resulting zip file"""
     bin_lid = parsed_pid['bin_lid']
     adc_cols = parsed_pid['adc_cols'].split(' ')
     targets = list(targets)

--- a/ifcb2/resolvers/ifcb.xml
+++ b/ifcb2/resolvers/ifcb.xml
@@ -140,6 +140,9 @@
 	<test var="product" eq="features">
 	  <var name="filename">${bin_lid}_fea_v2.csv</var>
 	</test>
+	<test var="product" eq="binzip">
+	  <var name="filename">${bin_lid}_binzip_v1.zip</var>
+	</test>
       </first>
       <any>
 	<!-- use the >=2014 standard directory patterns -->

--- a/ifcb2/workflow/__init__.py
+++ b/ifcb2/workflow/__init__.py
@@ -5,7 +5,7 @@ including workers for
 
 WILD_PRODUCT='wild'
 RAW_PRODUCT='raw'
-BIN_ZIP_PRODUCT='bin_zip'
+BIN_ZIP_PRODUCT='binzip'
 ACCESSION_ROLE='accession'
 
-BIN_ZIP_ROLE='bin_zip'
+BIN_ZIP_ROLE='binzip'

--- a/ifcb2/workflow/__init__.py
+++ b/ifcb2/workflow/__init__.py
@@ -5,4 +5,7 @@ including workers for
 
 WILD_PRODUCT='wild'
 RAW_PRODUCT='raw'
+BIN_ZIP_PRODUCT='bin_zip'
 ACCESSION_ROLE='accession'
+
+BIN_ZIP_ROLE='bin_zip'

--- a/ifcb2/workflow/__init__.py
+++ b/ifcb2/workflow/__init__.py
@@ -6,6 +6,9 @@ including workers for
 WILD_PRODUCT='wild'
 RAW_PRODUCT='raw'
 BIN_ZIP_PRODUCT='binzip'
-ACCESSION_ROLE='accession'
 
+ACCESSION_ROLE='accession'
 BIN_ZIP_ROLE='binzip'
+
+ACC_WAKEUP_KEY='ifcb:accession'
+BIN_ZIP_WAKEUP_KEY='ifcb:binzip'

--- a/ifcb2/workflow/acc_worker.py
+++ b/ifcb2/workflow/acc_worker.py
@@ -62,21 +62,19 @@ def acc_wakeup(wakeup_key):
                 raise Exception('accession failed')
             session.commit()
             # set product state in workflow
-            client.update(
+            client.complete(
                 pid,
                 state='available',
                 event='complete',
-                message='accession completed',
-                ttl=FOREVER)
+                message='accession completed')
             # now wake up zip worker
             client.wakeup(BIN_ZIP_WAKEUP_KEY)
         except Exception as e:
             logging.warn('ERROR during accession for %s' % pid)
-            client.update(
+            client.complete(
                 pid,
                 state='error',
                 event='exception',
-                message=str(e),
-                ttl=FOREVER)
+                message=str(e))
             # continue to next job
     logging.warn('no more accession jobs found, sleeping')

--- a/ifcb2/workflow/acc_worker.py
+++ b/ifcb2/workflow/acc_worker.py
@@ -10,8 +10,8 @@ from oii.workflow import FOREVER
 from oii.workflow.client import WorkflowClient
 from oii.workflow.async import async, wakeup_task
 from oii.ifcb2.workflow import WILD_PRODUCT, RAW_PRODUCT, ACCESSION_ROLE
+from oii.ifcb2.workflow import ACC_WAKEUP_KEY, BIN_ZIP_WAKEUP_KEY
 from oii.ifcb2.accession import Accession
-from oii.ifcb2.workflow.zip_worker import BIN_ZIP_WAKEUP_KEY
 
 """
 Here's the deal.
@@ -29,8 +29,6 @@ Scheduled task:
 from oii.ifcb2.session import session
 
 client = WorkflowClient()
-
-ACC_WAKEUP_KEY='ifcb:accession'
 
 @wakeup_task
 def acc_wakeup(wakeup_key):

--- a/ifcb2/workflow/acq_worker.py
+++ b/ifcb2/workflow/acq_worker.py
@@ -72,12 +72,15 @@ def acq_wakeup(wakeup_key):
     # attempt to acquire mutex. if fails, that's fine,
     # that means acquisition is aready underway
     try:
-        with Mutex(acq_key) as mutex:
+        with Mutex(acq_key,ttl=45) as mutex:
             # get the instrument info
             session.expire_all() # don't be stale!
             instrument = session.query(Instrument).\
                          filter(Instrument.name==instrument_name).\
                          first()
+            if instrument is None:
+                logging.warn('ERROR cannot find instrument named "%s"' % instrument_name)
+                return
             ts_label = instrument.time_series.label
             logging.warn('%s: starting acquisition cycle' % instrument_name)
             def callback(lid):

--- a/ifcb2/workflow/acq_worker.py
+++ b/ifcb2/workflow/acq_worker.py
@@ -8,6 +8,8 @@ from oii.workflow.client import WorkflowClient, Mutex, Busy
 from oii.workflow.async import async, wakeup_task
 from oii.ifcb2.workflow import WILD_PRODUCT, RAW_PRODUCT, ACCESSION_ROLE
 from oii.ifcb2.workflow.acc_worker import ACC_WAKEUP_KEY
+from oii.ifcb2.workflow import BIN_ZIP_ROLE, BIN_ZIP_PRODUCT
+from oii.ifcb2.workflow.zip_worker import BIN_ZIP_WAKEUP_KEY
 
 """
 Here's the deal.
@@ -41,10 +43,13 @@ def get_acq_key(instrument_name):
     
 def schedule_accession(client,pid):
     """use a oii.workflow.WorkflowClient to schedule an accession job for a fileset.
+    also schedule a downstream zip job.
     pid must not be a local id--it must be namespace-scoped"""
     wild_pid = as_product(pid,WILD_PRODUCT)
     raw_pid = as_product(pid,RAW_PRODUCT)
     client.depend(raw_pid, wild_pid, ACCESSION_ROLE)
+    zip_pid = as_product(pid,BIN_ZIP_PRODUCT)
+    client.depend(zip_pid, raw_pid, BIN_ZIP_ROLE)
 
 def copy_work(instrument,callback=None):
     """what an acquisition worker does"""

--- a/ifcb2/workflow/acq_worker.py
+++ b/ifcb2/workflow/acq_worker.py
@@ -7,9 +7,8 @@ from oii.ifcb2.orm import Instrument
 from oii.workflow.client import WorkflowClient, Mutex, Busy
 from oii.workflow.async import async, wakeup_task
 from oii.ifcb2.workflow import WILD_PRODUCT, RAW_PRODUCT, ACCESSION_ROLE
-from oii.ifcb2.workflow.acc_worker import ACC_WAKEUP_KEY
 from oii.ifcb2.workflow import BIN_ZIP_ROLE, BIN_ZIP_PRODUCT
-from oii.ifcb2.workflow.zip_worker import BIN_ZIP_WAKEUP_KEY
+from oii.ifcb2.workflow import ACC_WAKEUP_KEY, BIN_ZIP_WAKEUP_KEY
 
 """
 Here's the deal.

--- a/ifcb2/workflow/zip_worker.py
+++ b/ifcb2/workflow/zip_worker.py
@@ -24,15 +24,6 @@ def bin_zip_wakeup(wakeup_key):
         pid = job[PID]
         try:
             zip_path = get_product_destination(session, pid, 'binzip')
-            logging.warn('zip path = %s' % zip_path)
-            # now we need
-            """*parsed_pid - result of parsing pid
-            **problem** canonical_pid - canonicalized with URL prefix
-            targets - list of (stitched) targets
-            hdr - result of parsing header file
-            timestamp - timestamp (FIXME in what format?)
-            roi_path - path to ROI file
-            outfile - where to write resulting zip file"""
             client.complete(
                 pid,
                 state='available',

--- a/ifcb2/workflow/zip_worker.py
+++ b/ifcb2/workflow/zip_worker.py
@@ -1,7 +1,7 @@
 import logging
 
 from oii.ifcb2 import PID, LID, TS_LABEL
-from oii.ifcb2.workflow import BIN_ZIP_ROLE
+from oii.ifcb2.workflow import BIN_ZIP_ROLE, BIN_ZIP_WAKEUP_KEY
 
 from oii.workflow import FOREVER
 from oii.workflow.client import WorkflowClient
@@ -12,9 +12,7 @@ from oii.workflow.async import async, wakeup_task
 
 client = WorkflowClient()
 
-BIN_ZIP_WAKEUP_KEY='ifcb:binzip'
-
-#@wakeup_task
+@wakeup_task
 def bin_zip_wakeup(wakeup_key):
     if wakeup_key != BIN_ZIP_WAKEUP_KEY:
         logging.warn('BINZIP ignoring %s, sleeping' % wakeup_key)

--- a/ifcb2/workflow/zip_worker.py
+++ b/ifcb2/workflow/zip_worker.py
@@ -14,15 +14,15 @@ client = WorkflowClient()
 
 BIN_ZIP_WAKEUP_KEY='ifcb:binzip'
 
-@wakeup_task
+#@wakeup_task
 def bin_zip_wakeup(wakeup_key):
     if wakeup_key != BIN_ZIP_WAKEUP_KEY:
-        logging.warn('ignoring %s, sleeping' % wakeup_key)
+        logging.warn('BINZIP ignoring %s, sleeping' % wakeup_key)
         return
-    logging.warn('waking up for %s' % wakeup_key)
+    logging.warn('BINZIP waking up for %s' % wakeup_key)
     for job in client.start_all([BIN_ZIP_ROLE]):
         pid = job[PID]
-        logging.warn('MOCK completing job %s' % job)
+        logging.warn('BINZIP MOCK completing job %s' % job)
         client.update(
             pid,
             state='available',

--- a/ifcb2/workflow/zip_worker.py
+++ b/ifcb2/workflow/zip_worker.py
@@ -1,14 +1,16 @@
 import logging
 
+from oii.ifcb2 import get_resolver
 from oii.ifcb2 import PID, LID, TS_LABEL
+from oii.ifcb2.files import get_data_roots, get_product_destination
 from oii.ifcb2.workflow import BIN_ZIP_ROLE, BIN_ZIP_WAKEUP_KEY
+from oii.ifcb2.identifiers import as_product, parse_pid
 
-from oii.workflow import FOREVER
 from oii.workflow.client import WorkflowClient
 from oii.workflow.async import async, wakeup_task
 
 ### FIXME config this right
-#from oii.ifcb2.session import session
+from oii.ifcb2.session import session
 
 client = WorkflowClient()
 
@@ -20,10 +22,26 @@ def bin_zip_wakeup(wakeup_key):
     logging.warn('BINZIP waking up for %s' % wakeup_key)
     for job in client.start_all([BIN_ZIP_ROLE]):
         pid = job[PID]
-        logging.warn('BINZIP MOCK completing job %s' % job)
-        client.update(
-            pid,
-            state='available',
-            event='complete',
-            message='zip mock completed',
-            ttl=FOREVER)
+        try:
+            zip_path = get_product_destination(session, pid, 'binzip')
+            logging.warn('zip path = %s' % zip_path)
+            # now we need
+            """*parsed_pid - result of parsing pid
+            **problem** canonical_pid - canonicalized with URL prefix
+            targets - list of (stitched) targets
+            hdr - result of parsing header file
+            timestamp - timestamp (FIXME in what format?)
+            roi_path - path to ROI file
+            outfile - where to write resulting zip file"""
+            client.complete(
+                pid,
+                state='available',
+                event='complete',
+                message='pretended to create %s' % zip_path)
+        except Exception as e:
+            logging.warn('ERROR during zip for %s' % pid)
+            client.complete(
+                pid,
+                state='error',
+                event='exception',
+                message=str(e))

--- a/ifcb2/workflow/zip_worker.py
+++ b/ifcb2/workflow/zip_worker.py
@@ -3,6 +3,7 @@ import logging
 from oii.ifcb2 import PID, LID, TS_LABEL
 from oii.ifcb2.workflow import BIN_ZIP_ROLE
 
+from oii.workflow import FOREVER
 from oii.workflow.client import WorkflowClient
 from oii.workflow.async import async, wakeup_task
 
@@ -11,7 +12,7 @@ from oii.workflow.async import async, wakeup_task
 
 client = WorkflowClient()
 
-BIN_ZIP_WAKEUP_KEY='ifcb:bin_zip'
+BIN_ZIP_WAKEUP_KEY='ifcb:binzip'
 
 @wakeup_task
 def bin_zip_wakeup(wakeup_key):
@@ -22,4 +23,9 @@ def bin_zip_wakeup(wakeup_key):
     for job in client.start_all([BIN_ZIP_ROLE]):
         pid = job[PID]
         logging.warn('MOCK completing job %s' % job)
-        client.update(pid, state='available', event='complete', message='zip completed')
+        client.update(
+            pid,
+            state='available',
+            event='complete',
+            message='zip mock completed',
+            ttl=FOREVER)

--- a/ifcb2/workflow/zip_worker.py
+++ b/ifcb2/workflow/zip_worker.py
@@ -1,0 +1,25 @@
+import logging
+
+from oii.ifcb2 import PID, LID, TS_LABEL
+from oii.ifcb2.workflow import BIN_ZIP_ROLE
+
+from oii.workflow.client import WorkflowClient
+from oii.workflow.async import async, wakeup_task
+
+### FIXME config this right
+#from oii.ifcb2.session import session
+
+client = WorkflowClient()
+
+BIN_ZIP_WAKEUP_KEY='ifcb:bin_zip'
+
+@wakeup_task
+def bin_zip_wakeup(wakeup_key):
+    if wakeup_key != BIN_ZIP_WAKEUP_KEY:
+        logging.warn('ignoring %s, sleeping' % wakeup_key)
+        return
+    logging.warn('waking up for %s' % wakeup_key)
+    for job in client.start_all([BIN_ZIP_ROLE]):
+        pid = job[PID]
+        logging.warn('MOCK completing job %s' % job)
+        client.update(pid, state='available', event='complete', message='zip completed')

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,1 +1,34 @@
 # workflow-related utils
+
+# keys for use in the database and webapi
+
+PID='pid'
+
+# state and states
+STATE='state'
+NEW_STATE='new_state'
+WAITING='waiting'
+RUNNING='running'
+AVAILABLE='available'
+
+# expiration and timestamp
+TS='ts'
+EXPIRES='expires'
+TTL='ttl'
+FOREVER=-1
+
+# event and events
+EVENT='event'
+HEARTBEAT='heartbeat'
+RELEASED='released'
+
+# message
+MESSAGE='message'
+
+# role and roles
+ROLE='role'
+ANY='any'
+
+# dependencies
+UPSTREAM='upstream'
+

--- a/workflow/client.py
+++ b/workflow/client.py
@@ -61,8 +61,12 @@ class WorkflowClient(object):
     def delete_tree(self,pid):
         return requests.delete(self.api('/delete_tree/%s' % pid))
     def update(self,pid, **d):
-        """d can contain STATE, EVENT, MESSAGE"""
+        """d can contain STATE, EVENT, MESSAGE, TTL"""
         return requests.patch(self.api('/update/%s' % pid), data=d)
+    def complete(self,pid,**d):
+        """like update but sets TTL to FOREVER.
+        d can contain STATE, EVENT, MESSAGE"""
+        self.update(pid,**dict(d.items(),TTL=FOREVER))
     def heartbeat(self,pid,**d):
         d[EVENT] = HEARTBEAT
         return requests.patch(self.api('/update/%s' % pid), data=d)

--- a/workflow/client.py
+++ b/workflow/client.py
@@ -41,6 +41,15 @@ class WorkflowClient(object):
         if isinstance(roles,basestring):
             roles = [roles]
         return requests.get(self.api('/start_next/%s' % '/'.join(roles)))
+    def start_all(self,roles,expire=True):
+        while True:
+            if expire:
+                self.expire()
+            r = self.start_next(roles)
+            if not isok(r):
+                return
+            job = r.json()
+            yield job
     def create(self,pid,**d):
         return requests.put(self.api('/create/%s' % pid), data=d)
     def update_if(self,pid, **d):

--- a/workflow/client.py
+++ b/workflow/client.py
@@ -2,11 +2,11 @@ import requests
 
 from oii.utils import gen_id
 
-from oii.workflow.orm import STATE, NEW_STATE, EVENT, MESSAGE
-from oii.workflow.orm import WAITING, RUNNING, AVAILABLE
-from oii.workflow.orm import ROLE, ANY
-from oii.workflow.orm import HEARTBEAT, RELEASED
-from oii.workflow.orm import UPSTREAM
+from oii.workflow import STATE, NEW_STATE, EVENT, MESSAGE
+from oii.workflow import WAITING, RUNNING, AVAILABLE, FOREVER
+from oii.workflow import ROLE, ANY
+from oii.workflow import HEARTBEAT, RELEASED
+from oii.workflow import UPSTREAM
 
 from oii.workflow.webapi import DEFAULT_PORT
 
@@ -118,7 +118,12 @@ class Mutex(object):
         self.client.heartbeat(self.mutex_pid)
     def __exit__(self, exc_type, exc_value, traceback):
         # attempt to release the mutex into the WAITING state
-        r = self.client.update_if(self.mutex_pid, state=RUNNING, new_state=WAITING, event=RELEASED)
+        r = self.client.update_if(
+            self.mutex_pid,
+            state=RUNNING,
+            new_state=WAITING,
+            event=RELEASED,
+            ttl=FOREVER)
         if r.status_code == http.CONFLICT:
             # another client has forced the mutex out of the RUNNING state
             raise InconsistentState("mutex %s in inconsistent state" % self.mutex_pid)

--- a/workflow/orm.py
+++ b/workflow/orm.py
@@ -242,5 +242,4 @@ class Products(object):
             p.changed('expired', new_state)
             n += 1
         self.session.commit()
-        print '%d products expired' % n # FIXME debug
         return n

--- a/workflow/orm.py
+++ b/workflow/orm.py
@@ -8,36 +8,12 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from oii.times import utcdtnow
 from oii.orm_utils import fix_utc
 
-# keys for use in the database and webapi
-
-PID='pid'
-
-# state and states
-STATE='state'
-NEW_STATE='new_state'
-WAITING='waiting'
-RUNNING='running'
-AVAILABLE='available'
-
-# expiration and timestamp
-TS='ts'
-EXPIRES='expires'
-TTL='ttl'
-
-# event and events
-EVENT='event'
-HEARTBEAT='heartbeat'
-RELEASED='released'
-
-# message
-MESSAGE='message'
-
-# role and roles
-ROLE='role'
-ANY='any'
-
-# dependencies
-UPSTREAM='upstream'
+from oii.workflow import STATE, NEW_STATE, EVENT, MESSAGE
+from oii.workflow import WAITING, RUNNING, AVAILABLE
+from oii.workflow import TS, EXPIRES, TTL, FOREVER
+from oii.workflow import ROLE, ANY
+from oii.workflow import HEARTBEAT, RELEASED
+from oii.workflow import UPSTREAM
 
 # declarative SQLAlchemy ORM
 Base = declarative_base()
@@ -76,11 +52,19 @@ class Product(Base):
         if ts is None:
             ts = utcdtnow()
         self.ts = ts
-        if ttl is not None:
+        # expiration semantics:
+        # if ttl is never set, never expire
+        # if ttl is set to FOREVER, no longer expire
+        # if ttl is set to an integer, expire in that many seconds
+        # if ttl is None, make no change to expiration time or ttl
+        if ttl==FOREVER:
+            self.ttl = None
+            self.expires = None
+        elif ttl is not None:
             self.ttl = int(ttl)
+        if self.ttl is not None:
             self.expires = self.ts + timedelta(seconds=self.ttl)
         else:
-            self.ttl = None
             self.expires = None
 
     def deps_for_role(self, role):
@@ -195,6 +179,7 @@ class Products(object):
     def get_next(self, roles=[ANY], state=WAITING, dep_state=AVAILABLE):
         """find any product that is in state state and whose upstream dependencies are all in
         dep_state and satisfy all the specified roles, and lock it for update"""
+        self.session.expire_all() # don't be stale!
         return self.session.query(Product).\
             join(Product.upstream_dependencies).\
             filter(Product.state==state).\

--- a/workflow/orm.py
+++ b/workflow/orm.py
@@ -235,10 +235,12 @@ class Products(object):
         now = utcdtnow()
         n = 0
         for p in self.session.query(Product).\
+            filter(and_(Product.ttl.isnot(None),Product.ttl!=FOREVER)).\
             filter(Product.expires.isnot(None)).\
             filter(now > Product.expires).\
             with_lockmode('update'):
             p.changed('expired', new_state)
             n += 1
         self.session.commit()
+        print '%d products expired' % n # FIXME debug
         return n

--- a/workflow/webapi.py
+++ b/workflow/webapi.py
@@ -192,6 +192,7 @@ def update(pid):
     p = Products(session).get_product(pid, create=new_p)
     do_update(p, params)
     do_commit()
+    print 'PRODUCT %s -> %s' % (pid, params[STATE]) # FIXME debug
     return product_response(p)
 
 # assert a dependency between a downstream product and an upstream product,


### PR DESCRIPTION
Product workflows should all be remote, which raises issues with using non-canonical pids in the non-product acq/acc workflows. But the refactoring that was done towards writing a non-remote zipworker are needed in master, hence the merge.